### PR TITLE
Fix region signature mismatch issue

### DIFF
--- a/examples/checkbox.html
+++ b/examples/checkbox.html
@@ -47,8 +47,8 @@
     // If it's not working, try running tinyhost again and getting a fresh link
     
     const datastoreId = "ZTpiI4UlstqQtbiUyhQJ";
-    const presignedGetUrl = "https://tinyhost-tinyhost.s3.eu-west-2.amazonaws.com//ZTpiI4UlstqQtbiUyhQJ.json?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIA3QD3W4G7X5KR6Z6D%2F20241113%2Feu-west-2%2Fs3%2Faws4_request&X-Amz-Date=20241113T152947Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=84963b6a178aa831351eadc8df50534af314a572c056b1ed83e2b53fad6e5868";
-    const presignedPostDict = {"url": "https://tinyhost-tinyhost.s3.eu-west-2.amazonaws.com/", "fields": {"key": "/ZTpiI4UlstqQtbiUyhQJ.json", "x-amz-algorithm": "AWS4-HMAC-SHA256", "x-amz-credential": "AKIA3QD3W4G7X5KR6Z6D/20241113/eu-west-2/s3/aws4_request", "x-amz-date": "20241113T152947Z", "policy": "eyJleHBpcmF0aW9uIjogIjIwMjQtMTEtMjBUMTU6Mjk6NDdaIiwgImNvbmRpdGlvbnMiOiBbWyJjb250ZW50LWxlbmd0aC1yYW5nZSIsIDAsIDIwOTcxNTJdLCB7ImJ1Y2tldCI6ICJ0aW55aG9zdC10aW55aG9zdCJ9LCB7ImtleSI6ICIvWlRwaUk0VWxzdHFRdGJpVXloUUouanNvbiJ9LCB7IngtYW16LWFsZ29yaXRobSI6ICJBV1M0LUhNQUMtU0hBMjU2In0sIHsieC1hbXotY3JlZGVudGlhbCI6ICJBS0lBM1FEM1c0RzdYNUtSNlo2RC8yMDI0MTExMy9ldS13ZXN0LTIvczMvYXdzNF9yZXF1ZXN0In0sIHsieC1hbXotZGF0ZSI6ICIyMDI0MTExM1QxNTI5NDdaIn1dfQ==", "x-amz-signature": "12db469432a44e9dd553f638c5714e982d968ed37da2d300bae6b19ccf9c3b8f"}};
+    const presignedGetUrl = "https://jakep-tinyhost.s3.amazonaws.com//ZTpiI4UlstqQtbiUyhQJ.json?AWSAccessKeyId=AKIASHLPW4FEVZOPGK46&Signature=ZgVclvd%2FZTlEMNYD7%2FxsFXphIgI%3D&Expires=1727971300";
+    const presignedPostDict = {"url": "https://jakep-tinyhost.s3.amazonaws.com/", "fields": {"key": "/ZTpiI4UlstqQtbiUyhQJ.json", "AWSAccessKeyId": "AKIASHLPW4FEVZOPGK46", "policy": "eyJleHBpcmF0aW9uIjogIjIwMjQtMTAtMDNUMTY6MDE6NDBaIiwgImNvbmRpdGlvbnMiOiBbWyJjb250ZW50LWxlbmd0aC1yYW5nZSIsIDAsIDIwOTcxNTJdLCB7ImJ1Y2tldCI6ICJqYWtlcC10aW55aG9zdCJ9LCB7ImtleSI6ICIvWlRwaUk0VWxzdHFRdGJpVXloUUouanNvbiJ9XX0=", "signature": "4dnOkMB8BBjqLqD76yLV1x/lTFM="}};
     
     
     // Fetch state from the S3-backed datastore

--- a/examples/checkbox.html
+++ b/examples/checkbox.html
@@ -47,8 +47,8 @@
     // If it's not working, try running tinyhost again and getting a fresh link
     
     const datastoreId = "ZTpiI4UlstqQtbiUyhQJ";
-    const presignedGetUrl = "https://jakep-tinyhost.s3.amazonaws.com//ZTpiI4UlstqQtbiUyhQJ.json?AWSAccessKeyId=AKIASHLPW4FEVZOPGK46&Signature=ZgVclvd%2FZTlEMNYD7%2FxsFXphIgI%3D&Expires=1727971300";
-    const presignedPostDict = {"url": "https://jakep-tinyhost.s3.amazonaws.com/", "fields": {"key": "/ZTpiI4UlstqQtbiUyhQJ.json", "AWSAccessKeyId": "AKIASHLPW4FEVZOPGK46", "policy": "eyJleHBpcmF0aW9uIjogIjIwMjQtMTAtMDNUMTY6MDE6NDBaIiwgImNvbmRpdGlvbnMiOiBbWyJjb250ZW50LWxlbmd0aC1yYW5nZSIsIDAsIDIwOTcxNTJdLCB7ImJ1Y2tldCI6ICJqYWtlcC10aW55aG9zdCJ9LCB7ImtleSI6ICIvWlRwaUk0VWxzdHFRdGJpVXloUUouanNvbiJ9XX0=", "signature": "4dnOkMB8BBjqLqD76yLV1x/lTFM="}};
+    const presignedGetUrl = "https://tinyhost-tinyhost.s3.eu-west-2.amazonaws.com//ZTpiI4UlstqQtbiUyhQJ.json?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIA3QD3W4G7X5KR6Z6D%2F20241113%2Feu-west-2%2Fs3%2Faws4_request&X-Amz-Date=20241113T152947Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=84963b6a178aa831351eadc8df50534af314a572c056b1ed83e2b53fad6e5868";
+    const presignedPostDict = {"url": "https://tinyhost-tinyhost.s3.eu-west-2.amazonaws.com/", "fields": {"key": "/ZTpiI4UlstqQtbiUyhQJ.json", "x-amz-algorithm": "AWS4-HMAC-SHA256", "x-amz-credential": "AKIA3QD3W4G7X5KR6Z6D/20241113/eu-west-2/s3/aws4_request", "x-amz-date": "20241113T152947Z", "policy": "eyJleHBpcmF0aW9uIjogIjIwMjQtMTEtMjBUMTU6Mjk6NDdaIiwgImNvbmRpdGlvbnMiOiBbWyJjb250ZW50LWxlbmd0aC1yYW5nZSIsIDAsIDIwOTcxNTJdLCB7ImJ1Y2tldCI6ICJ0aW55aG9zdC10aW55aG9zdCJ9LCB7ImtleSI6ICIvWlRwaUk0VWxzdHFRdGJpVXloUUouanNvbiJ9LCB7IngtYW16LWFsZ29yaXRobSI6ICJBV1M0LUhNQUMtU0hBMjU2In0sIHsieC1hbXotY3JlZGVudGlhbCI6ICJBS0lBM1FEM1c0RzdYNUtSNlo2RC8yMDI0MTExMy9ldS13ZXN0LTIvczMvYXdzNF9yZXF1ZXN0In0sIHsieC1hbXotZGF0ZSI6ICIyMDI0MTExM1QxNTI5NDdaIn1dfQ==", "x-amz-signature": "12db469432a44e9dd553f638c5714e982d968ed37da2d300bae6b19ccf9c3b8f"}};
     
     
     // Fetch state from the S3-backed datastore

--- a/tinyhost/tinyhost.py
+++ b/tinyhost/tinyhost.py
@@ -5,15 +5,28 @@ import re
 import secrets
 import string
 import tempfile
+from typing import Optional
 
 import boto3
 import click
 import magic
+from botocore.config import Config
 from botocore.exceptions import ClientError, NoCredentialsError
 from bs4 import BeautifulSoup
 
 # Create an S3 client using boto3
-s3_client = boto3.client("s3")
+session = boto3.session.Session()
+aws_region = session.region_name or "us-east-1"
+
+# Create the S3 client with explicit endpoint configuration
+s3_client = boto3.client(
+    "s3",
+    region_name=aws_region,
+    config=Config(
+        signature_version='s3v4',
+        s3={'addressing_style': 'virtual'}
+    )
+)
 
 
 @click.command()
@@ -147,7 +160,12 @@ def tinyhost(html_file: str, bucket: str, prefix: str, duration: int, reset: boo
         )
 
         signed_url = s3_client.generate_presigned_url(
-            "get_object", Params={"Bucket": bucket, "Key": s3_key}, ExpiresIn=duration
+            'get_object',
+            Params={
+                'Bucket': bucket,
+                'Key': s3_key
+            },
+            ExpiresIn=duration
         )
 
         if signed_url:
@@ -188,8 +206,6 @@ def get_datastore_presigned_urls(bucket: str, prefix: str, datastore_id: str, du
     MAX_DATASTORE_SIZE = 2 * 1024 * 1024  # 2 Megabytes
     object_key = f"{prefix}/{datastore_id}.json"
 
-    # Check if object key exists, if not, make one, with the content {}
-    # and the right ContentType
     try:
         s3_client.head_object(Bucket=bucket, Key=object_key)
         print(f"Object {object_key} exists.")
@@ -202,16 +218,23 @@ def get_datastore_presigned_urls(bucket: str, prefix: str, datastore_id: str, du
             raise e
 
     get_url = s3_client.generate_presigned_url(
-        "get_object", Params={"Bucket": bucket, "Key": object_key}, ExpiresIn=duration
+        'get_object',
+        Params={
+            'Bucket': bucket,
+            'Key': object_key
+        },
+        ExpiresIn=duration
     )
 
-    # POST is used for the writing side, because it's the only way to ensure a maximum length
     post_conditions = [
         ["content-length-range", 0, MAX_DATASTORE_SIZE],
     ]
 
     post_dict = s3_client.generate_presigned_post(
-        Bucket=bucket, Key=object_key, Conditions=post_conditions, ExpiresIn=duration
+        Bucket=bucket,
+        Key=object_key,
+        Conditions=post_conditions,
+        ExpiresIn=duration
     )
 
     return get_url, post_dict
@@ -226,7 +249,7 @@ def compute_sha1_hash(file_path: str) -> str:
     return sha1.hexdigest()
 
 
-def run_new_bucket_flow() -> str:
+def run_new_bucket_flow() -> Optional[str]:
     sts_client = boto3.client("sts")
     identity = sts_client.get_caller_identity()
     arn = identity["Arn"]
@@ -243,11 +266,25 @@ def run_new_bucket_flow() -> str:
         error_code = e.response["Error"]["Code"]
         if error_code == "404":
             click.echo(f"Bucket {bucket} does not exist, attempting to create")
-
-            s3_client.create_bucket(Bucket=bucket)
-            return bucket
+            
+            try:
+                # For regions other than us-east-1, we need to specify LocationConstraint
+                if aws_region == "us-east-1":
+                    s3_client.create_bucket(Bucket=bucket)
+                else:
+                    s3_client.create_bucket(
+                        Bucket=bucket,
+                        CreateBucketConfiguration={
+                            'LocationConstraint': aws_region
+                        }
+                    )
+                return bucket
+            except ClientError as ce:
+                click.echo(f"Failed to create bucket: {ce}")
+                return None
         else:
-            raise RuntimeError(f"Error checking bucket existence: {e}")
+            click.echo(f"Error checking bucket existence: {e}")
+            return None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When trying to create a tinyhost instance with eu-west-2 there were signature mismatches at the pre-authed URL. These have been fixed by:
- Matching location constraints to region of bucket creation
- Specifying latest signature version
- Changing addressing_style to virtual to be more robust across regions

- [x] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/tinyhost/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/allenai/tinyhost/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.